### PR TITLE
Solución de error en comprobación al ingresar monto

### DIFF
--- a/controlador/egreso.py
+++ b/controlador/egreso.py
@@ -35,7 +35,7 @@ class ControladorEgreso(QtCore.QObject):
             )
             self.actualizar_balance.emit()
             self.__vista.close()
-        except Exception as error:
+        except (MontoError, TipoError, CategoriaError) as error:
             self.__vista.mostrar_error(error)
 
     def show_vista(self):

--- a/controlador/ingreso.py
+++ b/controlador/ingreso.py
@@ -35,7 +35,7 @@ class ControladorIngreso(QtCore.QObject):
             )
             self.actualizar_balance.emit()
             self.__vista.close()
-        except Exception as error:
+        except (MontoError, TipoError, CategoriaError) as error:
             self.__vista.mostrar_error(error)
 
     def show_vista(self):

--- a/modelo/egreso.py
+++ b/modelo/egreso.py
@@ -37,46 +37,48 @@ class ServiceEgreso:
         self.svc_categorias = ServiceCategoriaEgreso()
 
     def registrar_egreso(self, data: EgresoDTO):
+        try:
+            float(data.monto)
+        except ValueError:
+            raise MontoError
         if not data.id_tipo_transaccion:
             raise TipoError
         if not data.id_categoria:
             raise CategoriaError
-        try:
-            self.cursor.execute(
-                "INSERT INTO egresos (id, monto, tipo, categoria_egreso, descripcion, fecha) VALUES (%s, %s, %s, %s, %s, %s)",
-                (
-                    data.id,
-                    data.monto,
-                    data.id_tipo_transaccion,
-                    data.id_categoria,
-                    data.descripcion,
-                    data.fecha,
-                ),
-            )
-            self.database.commit()
-        except pymysql.Error:
-            raise MontoError
+        self.cursor.execute(
+            "INSERT INTO egresos (id, monto, tipo, categoria_egreso, descripcion, fecha) VALUES (%s, %s, %s, %s, %s, %s)",
+            (
+                data.id,
+                data.monto,
+                data.id_tipo_transaccion,
+                data.id_categoria,
+                data.descripcion,
+                data.fecha,
+            ),
+        )
+        self.database.commit()
 
     def editar_egreso(self, data: EgresoDTO):
+        try:
+            float(data.monto)
+        except ValueError:
+            raise MontoError
         if not data.id_tipo_transaccion:
             raise TipoError
         if not data.id_categoria:
             raise CategoriaError
-        try:
-            self.cursor.execute(
-                "UPDATE egresos SET monto=%s, tipo=%s, categoria_egreso=%s, descripcion=%s, fecha=%s WHERE id = %s",
-                (
-                    data.monto,
-                    data.id_tipo_transaccion,
-                    data.id_categoria,
-                    data.descripcion,
-                    data.fecha,
-                    data.id,
-                ),
-            )
-            self.database.commit()
-        except pymysql.Error:
-            raise MontoError
+        self.cursor.execute(
+            "UPDATE egresos SET monto=%s, tipo=%s, categoria_egreso=%s, descripcion=%s, fecha=%s WHERE id = %s",
+            (
+                data.monto,
+                data.id_tipo_transaccion,
+                data.id_categoria,
+                data.descripcion,
+                data.fecha,
+                data.id,
+            ),
+        )
+        self.database.commit()
 
     def eliminar_egreso(self, data: EgresoDTO):
         self.cursor.execute("DELETE FROM egresos WHERE id = %s", data.id)

--- a/modelo/ingreso.py
+++ b/modelo/ingreso.py
@@ -37,46 +37,48 @@ class ServiceIngreso:
         self.srv_categorias = ServiceCategoriaIngreso()
 
     def registrar_ingreso(self, data: IngresoDTO):
+        try:
+            float(data.monto)
+        except ValueError:
+            raise MontoError
         if not data.id_tipo_transaccion:
             raise TipoError
         if not data.id_categoria:
             raise CategoriaError
-        try:
-            self.cursor.execute(
-                "INSERT INTO ingresos (id, monto, tipo, categoria_ingreso, descripcion, fecha) VALUES (%s, %s, %s, %s, %s, %s)",
-                (
-                    data.id,
-                    data.monto,
-                    data.id_tipo_transaccion,
-                    data.id_categoria,
-                    data.descripcion,
-                    data.fecha,
-                ),
-            )
-            self.database.commit()
-        except pymysql.Error:
-            raise MontoError
+        self.cursor.execute(
+            "INSERT INTO ingresos (id, monto, tipo, categoria_ingreso, descripcion, fecha) VALUES (%s, %s, %s, %s, %s, %s)",
+            (
+                data.id,
+                data.monto,
+                data.id_tipo_transaccion,
+                data.id_categoria,
+                data.descripcion,
+                data.fecha,
+            ),
+        )
+        self.database.commit()
 
     def editar_ingreso(self, data: IngresoDTO):
+        try:
+            float(data.monto)
+        except ValueError:
+            raise MontoError
         if not data.id_tipo_transaccion:
             raise TipoError
         if not data.id_categoria:
             raise CategoriaError
-        try:
-            self.cursor.execute(
-                "UPDATE ingresos SET monto=%s, tipo=%s, categoria_ingreso=%s, descripcion=%s, fecha=%s WHERE id = %s",
-                (
-                    data.monto,
-                    data.id_tipo_transaccion,
-                    data.id_categoria,
-                    data.descripcion,
-                    data.fecha,
-                    data.id,
-                ),
-            )
-            self.database.commit()
-        except pymysql.Error:
-            raise MontoError
+        self.cursor.execute(
+            "UPDATE ingresos SET monto=%s, tipo=%s, categoria_ingreso=%s, descripcion=%s, fecha=%s WHERE id = %s",
+            (
+                data.monto,
+                data.id_tipo_transaccion,
+                data.id_categoria,
+                data.descripcion,
+                data.fecha,
+                data.id,
+            ),
+        )
+        self.database.commit()
 
     def eliminar_ingreso(self, data: IngresoDTO):
         self.cursor.execute("DELETE FROM ingresos WHERE id = %s", data.id)


### PR DESCRIPTION
Cambié la forma de disparar la excepción 'MontoError', ahora lo hace mediante un ValueError antes de la ejecución de la sentencia MySQL. 
Los controladores, ahora, capturan las excepciones propias del modelo de ingreso y egreso unicamente.